### PR TITLE
[PoolMetadataRegistry] Adding base contract and test

### DIFF
--- a/pkg/balancer-js/src/types.ts
+++ b/pkg/balancer-js/src/types.ts
@@ -13,6 +13,15 @@ export type FundManagement = {
   toInternalBalance: boolean;
 };
 
+// TODO(https://github.com/jiubeira/balancer-v2-monorepo/issues/7)
+// Double check whether this definition is necessary.
+export enum PoolMetadataRegistryTopic {
+  Tokenomics = 0,
+  Performance,
+  General,
+  Support,
+};
+
 // Swaps
 
 export enum SwapKind {

--- a/pkg/standalone-utils/contracts/PoolMetadataRegistry.sol
+++ b/pkg/standalone-utils/contracts/PoolMetadataRegistry.sol
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pragma solidity ^0.7.0;
+pragma experimental ABIEncoderV2;
+
+import "@balancer-labs/v2-solidity-utils/contracts/helpers/BalancerErrors.sol";
+
+/**
+ * @dev This contract emits events with metadata for existing pools,
+ * allowing users to post relevant information about them. 
+ * The events emitted by the contract can be then read and parsed from an off-chain app
+ * for visualization purposes.
+ */
+contract PoolMetadataRegistry {
+    // Index for metadata events, to be used as metadata unique identifiers.
+    uint256 private _nextMetadataIndex = 0;
+
+    // Metadata type identifier.
+    enum Topic { TOKENOMICS, PERFORMANCE, GENERAL, SUPPORT }
+
+    /**
+     * @dev Emitted on addMetadata()
+     * @param poolId The ID of the pool where the metadata belongs to.
+     * @param topic Metadata type identifier.
+     * @param data Relevant information for this metadata piece.
+     * @param id Metadata unique identifier set by the contract.
+     **/
+    event PoolMetadata(
+        bytes32 poolId,
+        Topic topic,
+        string data,
+        uint256 id
+    );
+
+    // TODO(https://github.com/jiubeira/balancer-v2-monorepo/issues/2):
+    // Replace this modifier with a proper valid pool check.
+    bytes32 private constant _POOL_ID_1 = "1";
+    bytes32 private constant _POOL_ID_2 = "2";
+    bytes32 private constant _POOL_ID_3 = "3";
+
+    modifier withRegisteredPool(bytes32 poolId) {
+        _require(
+            poolId == _POOL_ID_1 ||
+            poolId == _POOL_ID_2 ||
+            poolId == _POOL_ID_3,
+            Errors.INVALID_POOL_ID);
+        _;
+    }
+
+    function addMetadata(bytes32 poolId, Topic topic, string calldata data)
+        external
+        withRegisteredPool(poolId)
+    {
+        uint256 id = _nextMetadataIndex;
+        emit PoolMetadata(poolId, topic, data, id);
+        _nextMetadataIndex = _nextMetadataIndex + 1;
+    }
+}

--- a/pkg/standalone-utils/test/PoolMetadataRegistry.test.ts
+++ b/pkg/standalone-utils/test/PoolMetadataRegistry.test.ts
@@ -1,0 +1,85 @@
+import { expect } from 'chai';
+import { ethers } from 'hardhat';
+import { Contract } from 'ethers';
+import { deploy } from '@balancer-labs/v2-helpers/src/contract';
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/dist/src/signer-with-address';
+import { PoolMetadataRegistryTopic } from '@balancer-labs/balancer-js';
+import * as expectEvent from '@balancer-labs/v2-helpers/src/test/expectEvent';
+
+
+describe('PoolMetadataRegistry', function () {
+  let poolMetadataRegistry: Contract, admin: SignerWithAddress, user: SignerWithAddress;
+
+  before('setup signers', async () => {
+    [, admin, user] = await ethers.getSigners();
+  });
+
+  sharedBeforeEach('deploy pool metadata registry', async () => {
+    poolMetadataRegistry = await deploy('PoolMetadataRegistry', { from: admin });
+  });
+
+  describe('addMetadata', () => {
+    it('can add metadata to existing pools', async () => {
+      // As long as poolId and topic are valid, more than one metadata piece
+      // can be added to the same pool, even with matching topics.
+      // Metadata id is expected to increment with each call.
+      const metadataList = [
+        {
+          poolId: ethers.utils.formatBytes32String("1"),
+          topic: PoolMetadataRegistryTopic.Tokenomics,
+          data: 'Super interesting tokenomics',
+          id: 0,
+        },
+        {
+          poolId: ethers.utils.formatBytes32String("2"),
+          topic: PoolMetadataRegistryTopic.General,
+          data: 'General info',
+          id: 1,
+        },
+        {
+          poolId: ethers.utils.formatBytes32String("2"),
+          topic: PoolMetadataRegistryTopic.Performance,
+          data: 'Pool performance',
+          id: 2,
+        },
+        {
+          poolId: ethers.utils.formatBytes32String("3"),
+          topic: PoolMetadataRegistryTopic.Support,
+          data: 'Support page',
+          id: 3,
+        },
+        {
+          poolId: ethers.utils.formatBytes32String("1"),
+          topic: PoolMetadataRegistryTopic.Tokenomics,
+          data: 'More about tokenomics',
+          id: 4,
+        },
+      ];
+
+      for (const metadata of metadataList) {
+        const tx = await poolMetadataRegistry.connect(user).addMetadata(
+          metadata.poolId,
+          metadata.topic,
+          metadata.data);
+        const receipt = await tx.wait();
+        expectEvent.inReceipt(receipt, 'PoolMetadata', metadata);
+      }
+    });
+
+    it('tries to push invalid matadata and reverts', async () => {
+      let tx = poolMetadataRegistry.connect(user).addMetadata(
+        ethers.utils.formatBytes32String("0"),
+        PoolMetadataRegistryTopic.Tokenomics,
+        'Data');
+      await expect(tx).to.be.revertedWith('INVALID_POOL_ID');
+
+      // TODO(https://github.com/jiubeira/balancer-v2-monorepo/issues/6):
+      // Check if there's a better way of testing invalid enum inputs.
+      tx = poolMetadataRegistry.connect(user).addMetadata(
+        ethers.utils.formatBytes32String("1"),
+        1324,
+        'Data');
+      await expect(tx).to.be.reverted;
+    });
+  });
+});


### PR DESCRIPTION
- Implementing PoolMetadata events within a predefined set of topics.
- Mocking pool ID requirements temporarily.

Closes #1.