### PR TITLE
[PoolMetadataRegistry] Adding contract owner and flagging capability.

### DIFF
--- a/pkg/balancer-js/src/types.ts
+++ b/pkg/balancer-js/src/types.ts
@@ -22,6 +22,19 @@ export enum PoolMetadataRegistryTopic {
   Support,
 };
 
+export enum PoolMetadataRegistryMetadataType {
+  Content = 0,
+  Comment,
+};
+
+export enum PoolMetadataRegistryMetadataFlag {
+  Spam = 0,
+  Sponsored,
+  AdminReviewed,
+  Superseded,
+  Reply,
+};
+
 // Swaps
 
 export enum SwapKind {

--- a/pkg/standalone-utils/contracts/PoolMetadataRegistry.sol
+++ b/pkg/standalone-utils/contracts/PoolMetadataRegistry.sol
@@ -97,7 +97,7 @@ contract PoolMetadataRegistry is Ownable {
         external
         onlyOwner
     {
-        _require(metadataId <= _nextMetadataIndex, Errors.OUT_OF_BOUNDS);
+        _require(metadataId < _nextMetadataIndex, Errors.OUT_OF_BOUNDS);
         emit MetadataFlagged(metadataId, flag, note);
     }
 

--- a/pkg/standalone-utils/contracts/PoolMetadataRegistry.sol
+++ b/pkg/standalone-utils/contracts/PoolMetadataRegistry.sol
@@ -15,6 +15,8 @@
 pragma solidity ^0.7.0;
 pragma experimental ABIEncoderV2;
 
+import "@balancer-labs/v2-solidity-utils/contracts/openzeppelin/Ownable.sol";
+
 import "@balancer-labs/v2-solidity-utils/contracts/helpers/BalancerErrors.sol";
 import "@balancer-labs/v2-vault/contracts/interfaces/IVault.sol";
 
@@ -23,41 +25,102 @@ import "@balancer-labs/v2-vault/contracts/interfaces/IVault.sol";
  * allowing users to post relevant information about them. 
  * The events emitted by the contract can be then read and parsed from an off-chain app
  * for visualization purposes.
+ *
+ * The contract has an admin who can create content for existing pools.
+ * It also allows users to comment on pools, while the admin can moderate the comments
+ * by flagging them and commenting on them.
  */
-contract PoolMetadataRegistry {
+contract PoolMetadataRegistry is Ownable {
     // Index for metadata events, to be used as metadata unique identifiers.
     uint256 private _nextMetadataIndex = 0;
     // Vault reference to validate pool IDs.
     IVault private immutable _vault;
 
-    // Metadata type identifier.
+    // Metadata topic identifier.
     enum Topic { TOKENOMICS, PERFORMANCE, GENERAL, SUPPORT }
 
+    // Metadata type identifier.
+    enum MetadataType { CONTENT, COMMENT }
+
+    // Flags for metadata, set for comments by the admin.
+    enum MetadataFlag { SPAM, SPONSORED, ADMIN_REVIEWED, SUPERSEDED, REPLY }
+
     /**
-     * @dev Emitted on addMetadata()
+     * @dev Emitted on _createMetadata()
      * @param poolId The ID of the pool where the metadata belongs to.
      * @param topic Metadata type identifier.
      * @param data Relevant information for this metadata piece.
      * @param id Metadata unique identifier set by the contract.
      **/
-    event PoolMetadata(
+    event PoolMetadataCreated(
         bytes32 poolId,
         Topic topic,
         string data,
-        uint256 id
+        uint256 id,
+        MetadataType metadataType
+    );
+
+    /**
+     * @dev Emitted on flagMetadata()
+     * @param id Metadata unique identifier to flag.
+     * @param flag Flag type for metadata.
+     * @param note Extra information or comment for the metadata.
+     **/
+    event MetadataFlagged(
+        uint256 id,
+        MetadataFlag flag,
+        string note
     );
 
     constructor(IVault vault) {
         _vault = vault;
     }
 
-    function addMetadata(bytes32 poolId, Topic topic, string calldata data)
+    /**
+     * @notice Create content of a given topic for an existing pool.
+     * @dev Callable only by the owner. Reverts if the pool does not exist.
+     */
+    function createContent(bytes32 poolId, Topic topic, string calldata data)
         external
+        onlyOwner
+    {
+        _createMetadata(poolId, topic, data, MetadataType.CONTENT);
+    }
+
+    /**
+     * @notice Marks existing metadata with a flag and leaves a note.
+     * @dev Callable only by the owner. Reverts if metadata with the given ID was not created before.
+     * The same metadata piece can be flagged any amount of times with different flags.
+     * It is up to the app that consumes the event to display the information in a coherent way (e.g. show last flag).
+     */
+    function flagMetadata(uint256 metadataId, MetadataFlag flag, string calldata note)
+        external
+        onlyOwner
+    {
+        _require(metadataId <= _nextMetadataIndex, Errors.OUT_OF_BOUNDS);
+        emit MetadataFlagged(metadataId, flag, note);
+    }
+
+    /**
+     * @notice Create a comment of a given topic for an existing pool.
+     * @dev Reverts if the pool does not exist.
+     */
+    function createComment(bytes32 poolId, Topic topic, string calldata data)
+        external
+    {
+        _createMetadata(poolId, topic, data, MetadataType.COMMENT);
+    }
+
+    /**
+     * @dev Emits event with pool metadata.
+     */
+    function _createMetadata(bytes32 poolId, Topic topic, string calldata data, MetadataType metadataType)
+        private
     {
         // getPool will revert if the poolId is invalid.
         _vault.getPool(poolId);
         uint256 id = _nextMetadataIndex;
-        emit PoolMetadata(poolId, topic, data, id);
+        emit PoolMetadataCreated(poolId, topic, data, id, metadataType);
         _nextMetadataIndex = _nextMetadataIndex + 1;
     }
 }

--- a/pkg/standalone-utils/test/PoolMetadataRegistry.test.ts
+++ b/pkg/standalone-utils/test/PoolMetadataRegistry.test.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import { ethers } from 'hardhat';
 import { Contract } from 'ethers';
 import { deploy } from '@balancer-labs/v2-helpers/src/contract';
-import { PoolMetadataRegistryTopic } from '@balancer-labs/balancer-js';
+import { PoolMetadataRegistryMetadataFlag, PoolMetadataRegistryTopic, PoolMetadataRegistryMetadataType } from '@balancer-labs/balancer-js';
 import { PoolSpecialization } from '@balancer-labs/balancer-js';
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/dist/src/signer-with-address';
 
@@ -11,16 +11,60 @@ import { ZERO_ADDRESS } from '@balancer-labs/v2-helpers/src/constants';
 import * as expectEvent from '@balancer-labs/v2-helpers/src/test/expectEvent';
 
 
+type Metadata = {
+  poolId: String;
+  topic: Number;
+  data: String;
+  id: Number;
+  metadataType: PoolMetadataRegistryMetadataType;
+};
+
+function createMetadataList(poolIds: Array<String>, metadataType: PoolMetadataRegistryMetadataType): Array<Metadata> {
+  let index = 0;
+  let metadataList = [];
+
+  // As long as poolId and topic are valid, more than one metadata piece
+  // can be added to the same pool, even with matching topics.
+  // Metadata id is expected to increment with each call.
+  for (const poolId of poolIds) {
+    for (let topic in PoolMetadataRegistryTopic) {
+      let topicNumber = Number(topic);
+      if (isNaN(topicNumber)) {
+        continue;
+      }
+
+      const metadata1 = {
+        poolId: poolId,
+        topic: topicNumber,
+        data: `Data for ${poolId}, topic ${topic} at index ${index}`,
+        id: index++,
+        metadataType: metadataType,
+      }
+      const metadata2 = {
+        poolId: poolId,
+        topic: topicNumber,
+        data: `More data for ${poolId}, topic ${topic} at index ${index}`,
+        id: index++,
+        metadataType: metadataType,
+      }
+      metadataList.push(metadata1);
+      metadataList.push(metadata2);
+    }
+  }
+  return metadataList;
+}
+
 describe('PoolMetadataRegistry', function () {
   let poolMetadataRegistry: Contract, admin: SignerWithAddress, user: SignerWithAddress, vault: Contract;
-  let poolIds: Array<String>;
+  let poolIds: Array<String>, validPoolId: String, invalidPoolId: String, validTopic: PoolMetadataRegistryTopic;
+  let invalidTopic: Number;
 
   before('setup signers', async () => {
     [, admin, user] = await ethers.getSigners();
   });
 
-  sharedBeforeEach('deploy and initialize vault and pools', async () => {
-    const poolCount = 3;
+  before('deploy and initialize vault and pools', async () => {
+    const poolCount = 2;
     vault = await deploy('v2-vault/Vault', { args: [ZERO_ADDRESS, ZERO_ADDRESS, 0, 0] });
 
     poolIds = [];
@@ -30,74 +74,153 @@ describe('PoolMetadataRegistry', function () {
     }
   });
 
+  before('initialize common variables', () => {
+    validPoolId = poolIds[0];
+    invalidPoolId = ethers.utils.formatBytes32String("Invalid pool ID");
+    validTopic = PoolMetadataRegistryTopic.Tokenomics;
+    invalidTopic = 123456;
+  });
+
   sharedBeforeEach('deploy pool metadata registry', async () => {
     poolMetadataRegistry = await deploy(
         'PoolMetadataRegistry',
         { from: admin, args: [vault.address] });
   });
 
-  describe('addMetadata', () => {
-    it('can add metadata to existing pools', async () => {
-      // As long as poolId and topic are valid, more than one metadata piece
-      // can be added to the same pool, even with matching topics.
-      // Metadata id is expected to increment with each call.
-      const metadataList = [
-        {
-          poolId: poolIds[0],
-          topic: PoolMetadataRegistryTopic.Tokenomics,
-          data: 'Super interesting tokenomics',
-          id: 0,
-        },
-        {
-          poolId: poolIds[1],
-          topic: PoolMetadataRegistryTopic.General,
-          data: 'General info',
-          id: 1,
-        },
-        {
-          poolId: poolIds[1],
-          topic: PoolMetadataRegistryTopic.Performance,
-          data: 'Pool performance',
-          id: 2,
-        },
-        {
-          poolId: poolIds[2],
-          topic: PoolMetadataRegistryTopic.Support,
-          data: 'Support page',
-          id: 3,
-        },
-        {
-          poolId: poolIds[0],
-          topic: PoolMetadataRegistryTopic.Tokenomics,
-          data: 'More about tokenomics',
-          id: 4,
-        },
-      ];
-
+  describe('createContent', () => {
+    it('can add content to existing pools', async () => {
+      let metadataList = createMetadataList(poolIds, PoolMetadataRegistryMetadataType.Content);
       for (const metadata of metadataList) {
-        const tx = await poolMetadataRegistry.connect(user).addMetadata(
+        const tx = await poolMetadataRegistry.connect(admin).createContent(
           metadata.poolId,
           metadata.topic,
           metadata.data);
         const receipt = await tx.wait();
-        expectEvent.inReceipt(receipt, 'PoolMetadata', metadata);
+        expectEvent.inReceipt(receipt, 'PoolMetadataCreated', metadata);
       }
     });
 
     it('tries to push invalid matadata and reverts', async () => {
-      let tx = poolMetadataRegistry.connect(user).addMetadata(
-        ethers.utils.formatBytes32String("Invalid pool ID"),
-        PoolMetadataRegistryTopic.Tokenomics,
+      let tx = poolMetadataRegistry.connect(admin).createContent(
+        invalidPoolId,
+        validTopic,
         'Data');
       await expect(tx).to.be.revertedWith('INVALID_POOL_ID');
 
       // TODO(https://github.com/jiubeira/balancer-v2-monorepo/issues/6):
       // Check if there's a better way of testing invalid enum inputs.
-      tx = poolMetadataRegistry.connect(user).addMetadata(
-        poolIds[0],
-        1324,
+      tx = poolMetadataRegistry.connect(admin).createContent(
+        validPoolId,
+        invalidTopic,
         'Data');
       await expect(tx).to.be.reverted;
+    });
+
+    it('tries to create content without admin rights', async () => {
+      let tx = poolMetadataRegistry.connect(user).createContent(
+        validPoolId,
+        validTopic,
+        'I do not have admin rights, but let\s try anyways');
+      await expect(tx).to.be.revertedWith('CALLER_IS_NOT_OWNER');
+    });
+  });
+
+  describe('createComment', () => {
+    it('can add comments to existing pools', async () => {
+      let metadataList = createMetadataList(poolIds, PoolMetadataRegistryMetadataType.Comment);
+      for (const metadata of metadataList) {
+        const tx = await poolMetadataRegistry.connect(user).createComment(
+          metadata.poolId,
+          metadata.topic,
+          metadata.data);
+        const receipt = await tx.wait();
+        expectEvent.inReceipt(receipt, 'PoolMetadataCreated', metadata);
+      }
+    });
+
+    it('tries to push invalid matadata and reverts', async () => {
+      let tx = poolMetadataRegistry.connect(admin).createComment(
+        invalidPoolId,
+        validTopic,
+        'Data');
+      await expect(tx).to.be.revertedWith('INVALID_POOL_ID');
+
+      // TODO(https://github.com/jiubeira/balancer-v2-monorepo/issues/6):
+      // Check if there's a better way of testing invalid enum inputs.
+      tx = poolMetadataRegistry.connect(admin).createComment(
+        validPoolId,
+        invalidTopic,
+        'Data');
+      await expect(tx).to.be.reverted;
+    });
+  });
+
+  describe('flagMetadata', () => {
+    const validMetadataId = 1;
+    const invalidMetadataId = 123456;
+    sharedBeforeEach('add some metadata to existing pools', async () => {
+      await (await poolMetadataRegistry.connect(admin).createContent(
+        validPoolId,
+        validTopic,
+        'Content by admin')).wait();
+      await (await poolMetadataRegistry.connect(user).createComment(
+        validPoolId,
+        validTopic,
+        'Interesting comment by user')).wait();
+      await (await poolMetadataRegistry.connect(user).createComment(
+        validPoolId,
+        validTopic,
+        'Spam comment by user')).wait();
+    });
+
+    it('flags some user comments', async () => {
+      const metadataReviewedFlagEvent = {
+        id: 1,
+        flag: PoolMetadataRegistryMetadataFlag.AdminReviewed,
+        note: 'Thanks for the comment!'
+      };
+      let tx = await poolMetadataRegistry.connect(admin).flagMetadata(
+        metadataReviewedFlagEvent.id,
+        metadataReviewedFlagEvent.flag,
+        metadataReviewedFlagEvent.note);
+      let receipt = await tx.wait();
+      expectEvent.inReceipt(receipt, 'MetadataFlagged', metadataReviewedFlagEvent);
+
+      const metadataSpamEvent = {
+        id: 2,
+        flag: PoolMetadataRegistryMetadataFlag.Spam,
+        note: 'Comment marked as inappropriate by admin.'
+      };
+      tx = await poolMetadataRegistry.connect(admin).flagMetadata(
+        metadataSpamEvent.id,
+        metadataSpamEvent.flag,
+        metadataSpamEvent.note);
+      receipt = await tx.wait();
+      expectEvent.inReceipt(receipt, 'MetadataFlagged', metadataSpamEvent);
+    });
+
+    it('tries to flag metadata incorrectly and reverts', async () => {
+      let tx = poolMetadataRegistry.connect(admin).flagMetadata(
+        invalidMetadataId,
+        PoolMetadataRegistryMetadataFlag.Spam,
+        'Marked as spam by admin');
+      await expect(tx).to.be.revertedWith('OUT_OF_BOUNDS');
+
+      // TODO(https://github.com/jiubeira/balancer-v2-monorepo/issues/6):
+      // Check if there's a better way of testing invalid enum inputs.
+      tx = poolMetadataRegistry.connect(admin).flagMetadata(
+        1,
+        1234,
+        'Data');
+      await expect(tx).to.be.reverted;
+    });
+
+    it('tries to moderate without admin rights', async () => {
+      let tx = poolMetadataRegistry.connect(user).flagMetadata(
+        validMetadataId,
+        PoolMetadataRegistryMetadataFlag.Spam,
+        'I do not have admin rights, but let\s try anyways');
+      await expect(tx).to.be.revertedWith('CALLER_IS_NOT_OWNER');
     });
   });
 });


### PR DESCRIPTION
- Contract now is Ownable.
- Owners can post content and comments, users can only comment.
- Owners can moderate and reply to comments.
- Adjusting unit tests.

Closes #3 